### PR TITLE
updated sdk installation links

### DIFF
--- a/docs/TrialAccounts/Creation/getting-started.md
+++ b/docs/TrialAccounts/Creation/getting-started.md
@@ -11,7 +11,7 @@ In the following tutorials, you'll learn how Trial Accounts work behind the scen
 In order to successfully complete the tutorials, you'll need to have the following:
 
 1. [Node JS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
-2. [Keypom JS SDK](https://github.com/keypom/keypom-js#installation)
+2. [Keypom JS SDK](https://github.com/keypom/keypom-js#getting-started)
 
 ---
 

--- a/docs/Tutorials/Advanced/ticketing/introduction.md
+++ b/docs/Tutorials/Advanced/ticketing/introduction.md
@@ -31,7 +31,7 @@ For the this tutorial, you can choose to run the scripts on your own machine. To
 
 1. [Node JS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
 2. [NEAR-API-JS](https://docs.near.org/tools/near-api-js/quick-reference#install)  
-3. [Keypom JS SDK](https://github.com/keypom/keypom-js#installation)
+3. [Keypom JS SDK](https://github.com/keypom/keypom-js#getting-started)
 
 If you want to reference the finished code, that can be found [here](https://github.com/keypom/keypom-js/tree/min/ticketing-tutorial/docs-advanced-tutorials/ticket-app). To follow along and build out this ticketing app, see the steps below. 
 

--- a/docs/Tutorials/Basics/fc-drops.md
+++ b/docs/Tutorials/Basics/fc-drops.md
@@ -24,7 +24,7 @@ For the basic tutorials, you can choose to run the scripts on your own machine. 
 
 1. [Node JS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
 2. [NEAR-API-JS](https://docs.near.org/tools/near-api-js/quick-reference#install)  
-3. [Keypom JS SDK](https://github.com/keypom/keypom-js#installation)
+3. [Keypom JS SDK](https://github.com/keypom/keypom-js#getting-started)
 
 With this tutorial, you can either create your own script by following along, or view the completed script available in the [Keypom Documentation Examples](https://github.com/keypom/keypom-docs-examples) repo.
 

--- a/docs/Tutorials/Basics/ft-drops.md
+++ b/docs/Tutorials/Basics/ft-drops.md
@@ -21,7 +21,7 @@ For the basic tutorials, you can choose to run the scripts on your own machine. 
 
 1. [Node JS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
 2. [NEAR-API-JS](https://docs.near.org/tools/near-api-js/quick-reference#install)  
-3. [Keypom JS SDK](https://github.com/keypom/keypom-js#installation)
+3. [Keypom JS SDK](https://github.com/keypom/keypom-js#getting-started)
 
 With this tutorial, you can either create your own script by following along, or view the completed script available in the [Keypom Documentation Examples](https://github.com/keypom/keypom-docs-examples) repo.
 

--- a/docs/Tutorials/Basics/getting-started.md
+++ b/docs/Tutorials/Basics/getting-started.md
@@ -34,7 +34,7 @@ For the basic tutorials, you can choose to run the scripts on your own machine. 
 
 1. [Node JS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
 2. [NEAR-API-JS](https://docs.near.org/tools/near-api-js/quick-reference#install)  
-3. [Keypom JS SDK](https://github.com/keypom/keypom-js#installation)
+3. [Keypom JS SDK](https://github.com/keypom/keypom-js#getting-started)
 
 At this point, you are ready to start the tutorials.
 

--- a/docs/Tutorials/Basics/nft-drops.md
+++ b/docs/Tutorials/Basics/nft-drops.md
@@ -21,7 +21,7 @@ For the basic tutorials, you can choose to run the scripts on your own machine. 
 
 1. [Node JS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
 2. [NEAR-API-JS](https://docs.near.org/tools/near-api-js/quick-reference#install)  
-3. [Keypom JS SDK](https://github.com/keypom/keypom-js#installation)
+3. [Keypom JS SDK](https://github.com/keypom/keypom-js#getting-started)
 
 With this tutorial, you can either create your own script by following along, or view the completed script available in the [Keypom Documentation Examples](https://github.com/keypom/keypom-docs-examples) repo.
 

--- a/docs/Tutorials/Basics/simple-drops.md
+++ b/docs/Tutorials/Basics/simple-drops.md
@@ -22,7 +22,7 @@ For the basic tutorials, you can choose to run the scripts on your own machine. 
 
 1. [Node JS](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)  
 2. [NEAR-API-JS](https://docs.near.org/tools/near-api-js/quick-reference#install)  
-3. [Keypom JS SDK](https://github.com/keypom/keypom-js#installation)
+3. [Keypom JS SDK](https://github.com/keypom/keypom-js#getting-started)
 
 With this tutorial, you can either create your own script by following along, or view the completed script available in the [Keypom Documentation Examples](https://github.com/keypom/keypom-docs-examples) repo.
 


### PR DESCRIPTION
Tutorial prerequisites were linking to a non-existent section in the readme and redirecting to just the repo rather than the installation instructions.